### PR TITLE
Remove Oudated Homepage Info

### DIFF
--- a/pages/index.liquid
+++ b/pages/index.liquid
@@ -28,19 +28,7 @@ eleventyNavigation:
     Our focus is on students in 5th-12th grades but may include programs for people of marginalized genders of all ages.
   </p>
 
-  <div class="getconf-image">
-    <a href="https://getconfomaha.com/" target="blank">
-      <img
-        alt="GetConf 2019"
-        src="assets/images/getconf.png"
-      >
-    </a>
-  </div>
-
   <div class="board">
-    <p>
-      Our board members are Rachel Fox, Wendy Holley, Shannon Jackson, Eris Koleszar, Stefanie Monge, Laurel Oetken, Jessica Selde, and Morgan Smith.
-    </p>
     <img src="assets/images/board-members.jpg" alt="board members">
   </div>
 </section>


### PR DESCRIPTION
Removes the 2019 GETconf banner and outdated board member list from the homepage (I didn't update this since it's current on the volunteers page).